### PR TITLE
Python api debug

### DIFF
--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -125,6 +125,7 @@ void shardAllLike(TensorView* ref, std::vector<TensorView*> tvs) {
 } // namespace
 
 void insertReshardings(Fusion* fusion) {
+  FusionGuard fg(fusion);
   auto exprs = fusion->exprs();
   for (auto expr : exprs) {
     if (isLowerableToCommunication(expr)) {

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -210,7 +210,7 @@ struct DimInfo {
   std::optional<bool> contiguity = std::nullopt;
 
   bool isBroadcast() {
-    return stride == 0 || size == 1;
+    return false; // this might seenm brutal, but how check if the axis is cheduled to be sharded ?
   }
 };
 
@@ -752,7 +752,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             if (contiguity.empty()) {
               for (const auto dim_size : shape) {
                 if (dim_size == 1) {
-                  contiguity.emplace_back(std::nullopt);
+                  contiguity.emplace_back(false); // should be false if the axis is sharded...
                 } else {
                   contiguity.emplace_back(false);
                 }
@@ -795,7 +795,7 @@ void initNvFuserPythonBindings(PyObject* module) {
                 strides.size());
 
             // TensorViewBuilder assumes any dim with a compile time constant
-            // size == 1 is a "maybe broadcast" axis, symbolic sizes are
+            // size == 1 is a "maybe broadcast" axis (what does it mean?), symbolic sizes are
             // identified by -1, and size == 0 is not supported.
 
             // Translate to TensorViewBuilder's view of the world.
@@ -811,7 +811,7 @@ void initNvFuserPythonBindings(PyObject* module) {
                 dim_sizes.push_back(sizes[i]);
               } else { // Symbolic defined tensor for dynamic shape usage
                 if (sizes[i] == 1) {
-                  dim_sizes.push_back(1);
+                  dim_sizes.push_back(-1); // why a special case for size=1 here?
                 } else {
                   dim_sizes.push_back(-1);
                 }

--- a/python_tests/mpi_test.py
+++ b/python_tests/mpi_test.py
@@ -24,9 +24,9 @@ class MultiDeviceModel(FusionDefinition):
 
     def definition(self):
         # dynamic shape isn't working? at least I'm getting asserts
-        #self.t0 = self.from_pytorch(inputs[0])
+        self.t0 = self.from_pytorch(inputs[0])
 
-        self.t0 = self.define_tensor((2, 4), (False, False), dtype=DataType.Float)
+        # self.t0 = self.define_tensor((2, 4), (False, False), dtype=DataType.Float)
 
         # looks like I cannot have scalar inputs to any expression, hitting an assert
         #self.s0 = self.define_constant(2.0)

--- a/python_tests/mpi_test.py
+++ b/python_tests/mpi_test.py
@@ -33,9 +33,9 @@ class MultiDeviceModel(FusionDefinition):
         #self.t1 = self.ops.mul(self.t0, self.s0)
 
         # relu seems to also be complaining, I assume sharding operation has to be a set
-        #self.t1 = self.ops.relu(self.t0)
+        self.t1 = self.ops.relu(self.t0)
 
-        self.t1 = self.ops.set(self.t0)
+        # self.t1 = self.ops.set(self.t0)
         self.t2 = self.ops.add(self.t1, self.t1)
         self.add_output(self.t2)
 


### PR DESCRIPTION
This PR attempts to fix all the bugs revealed by the Python test
MAIN PR: https://github.com/NVIDIA/Fuser/pull/1935

- The [first commit](https://github.com/jjsjann123/Fuser/pull/2/commits/51e0bdc32bf729c5525e39a17f9046a5ab5f66e1) fixes the support for "non-set resharding" ops (aka `relu` in the example). The fix is very simple (one-line) and is intrinsic to the multidevice core implementation

The other commits attempt to fix the support for dynamic shapes. TL;DR I think for now we should focus on static shapes and not worry too much on dynamic shapes since it might require change in the API.
Basically, there are two distinct issues:
- First of all, the Python API seems to make special assumption for input sizes of 1. More precisely, the Python layer does not allow such dimensions to be symbolic, and treats them as static broadcast dimensions. However, Sharded dimensions are locally of size 1 but their symbolic shape is different, so they shouldn't be treated as they currently are. We need here an option to disable this behavior. The [third commit](https://github.com/jjsjann123/Fuser/pull/2/commits/2b278f73c985510cecbd37f3820871d75f08b613) (brutally) turns off this behavior to demonstrate that this is the reason why the test is not working with dynamic shapes. This might require further discussion on how to modify the API to integrate sharded tensors.
- Lastly, the test with dynamic shape+relu reveals another issue. If we want to support dynamic shapes and manual scheduling, even to be functional we need to add some scheduling primitive, e.g. `setMemoryType`, since without it, we might run into [this assert](https://github.com/NVIDIA/Fuser/blob/70cf7a371bf4603c30e3e2523469c75e749639fd/csrc/executor.cpp#L431). This is supported by the [second commit](https://github.com/jjsjann123/Fuser/pull/2/commits/ed83197a1fd1439018365111c12f3077169a916c) which reproduces the sample test as the python test with the C++ API and shows that the test runs successfully if we set the memory type properly
